### PR TITLE
Fix to docker build error with flask import

### DIFF
--- a/my-python-app/minitwit/minitwit.py
+++ b/my-python-app/minitwit/minitwit.py
@@ -15,7 +15,7 @@ from hashlib import md5
 from datetime import datetime
 from flask import Flask, request, session, url_for, redirect, \
      render_template, abort, g, flash, _app_ctx_stack
-from werkzeug import check_password_hash, generate_password_hash
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 # configuration


### PR DESCRIPTION
Was facing below issue while building docker image : 

```sh
Step 7/10 : RUN flask --help
 ---> Running in d15c0705fbaa
Usage: flask [OPTIONS] COMMAND [ARGS]...

  A general utility script for Flask applications.

  Provides commands from Flask, extensions, and the application. Loads the
  application defined in the FLASK_APP environment variable, or from a
  wsgi.py file. Setting the FLASK_ENV environment variable to 'development'
  will enable debug mode.

    $ export FLASK_APP=hello.py
    $ export FLASK_ENV=development
    $ flask run

Options:
  --version  Show the flask version
  --help     Show this message and exit.

Commands:
  routes  Show the routes for the app.
  run     Run a development server.
  shell   Run a shell in the app context.
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 240, in locate_app
    __import__(module_name)
  File "/app/minitwit/__init__.py", line 1, in <module>
    from .minitwit import app
  File "/app/minitwit/minitwit.py", line 18, in <module>
    from werkzeug import check_password_hash, generate_password_hash
ImportError: cannot import name 'check_password_hash'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 556, in list_commands
    rv.update(info.load_app().cli.list_commands(ctx))
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 388, in load_app
    app = locate_app(self, import_name, name)
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 247, in locate_app
    "\n\n{tb}".format(name=module_name, tb=traceback.format_exc())
flask.cli.NoAppException: While importing "minitwit.minitwit", an ImportError was raised:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 240, in locate_app
    __import__(module_name)
  File "/app/minitwit/__init__.py", line 1, in <module>
    from .minitwit import app
  File "/app/minitwit/minitwit.py", line 18, in <module>
    from werkzeug import check_password_hash, generate_password_hash
ImportError: cannot import name 'check_password_hash'

Removing intermediate container d15c0705fbaa
 ---> fdc4f8b91e08
Step 8/10 : RUN flask initdb
 ---> Running in 0a783728976f
Usage: flask [OPTIONS] COMMAND [ARGS]...
Try 'flask --help' for help.

Error: No such command 'initdb'.


```

I found the fix that `check_password_hash` and `generate_password_hash` have been moved to `werkzeug.security ` from `werkzeug`.

Updated code and now it's running successful.

**Note**: In above `docker` build logs `RUN flask --help` has been added as a part of my debug to identify actual issue `flask initdb`, So that is not added in this commit. 